### PR TITLE
Future times are failing (example test case).

### DIFF
--- a/timeago_test.go
+++ b/timeago_test.go
@@ -52,6 +52,9 @@ var formatReferenceTests = []struct {
 	{tBase, tBase.Add(90 * time.Minute).Add(-1), NoMax(English), "about an hour ago"},
 	{tBase, tBase.Add(90 * time.Minute).Add(-1), WithMax(English, 90*time.Minute, ""), "about an hour ago"},
 	{tBase, tBase.Add(90 * time.Minute), WithMax(English, 90*time.Minute, "2006-01-02"), "2013-08-30"},
+	
+	//Future
+	{tBase.Add(24 * time.Hour), tBase, NoMax(English), "in one day"},
 }
 
 //Test the FormatReference method


### PR DESCRIPTION
Hi there, I happened to stumble on your library apparently an hour after you published it. :)

I noticed you plan to add support for future times, but looks like they're not functional yet. In case you didn't know, I wrote a simple test case.

```
$ go test .
--- FAIL: TestFormatReference (0.00 seconds)
    timeago_test.go:65: 29) FormatReference(2013-08-31 12:00:00 +0000 UTC,2013-08-30 12:00:00 +0000 UTC): expected in one day, actual in about a second
FAIL
FAIL    github.com/xeonx/timeago    0.032s
```
